### PR TITLE
Fix this error:

### DIFF
--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -37,7 +37,7 @@ declare module "sql" {
 	interface TableDefinition<Name extends string, Row> {
 		name: Name;
 		schema: string;
-		columns: {[CName in keyof Row]: CName extends string? ColumnDefinition<CName, Row[CName]>: never};
+		columns: {[CName in Extract< keyof Row, string >]: ColumnDefinition<CName, Row[CName]>};
 		dialect?: SQLDialects;
 		isTemporary?: boolean;
 		foreignKeys?: {

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -37,7 +37,7 @@ declare module "sql" {
 	interface TableDefinition<Name extends string, Row> {
 		name: Name;
 		schema: string;
-		columns: {[CName in keyof Row]: ColumnDefinition<CName, Row[CName]>};
+		columns: {[CName in keyof Row]: CName extends string? ColumnDefinition<CName, Row[CName]: never>};
 		dialect?: SQLDialects;
 		isTemporary?: boolean;
 		foreignKeys?: {

--- a/lib/types.d.ts
+++ b/lib/types.d.ts
@@ -37,7 +37,7 @@ declare module "sql" {
 	interface TableDefinition<Name extends string, Row> {
 		name: Name;
 		schema: string;
-		columns: {[CName in keyof Row]: CName extends string? ColumnDefinition<CName, Row[CName]: never>};
+		columns: {[CName in keyof Row]: CName extends string? ColumnDefinition<CName, Row[CName]>: never};
 		dialect?: SQLDialects;
 		isTemporary?: boolean;
 		foreignKeys?: {


### PR DESCRIPTION
node_modules/sql/lib/types.d.ts:40:52 - error TS2344: Type 'CName' does not satisfy the constraint 'string'.
  Type 'keyof Row' is not assignable to type 'string'.
    Type 'string | number | symbol' is not assignable to type 'string'.
      Type 'number' is not assignable to type 'string'.